### PR TITLE
Update Typography: Replace Geist fonts with Inter and IBM Plex Mono

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-inter);
+  --font-mono: var(--font-ibm-plex-mono);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter), system-ui, sans-serif;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,18 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/layout/Header";
 import QueryProvider from "@/components/providers/QueryProvider";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const ibmPlexMono = IBM_Plex_Mono({
+  variable: "--font-ibm-plex-mono",
   subsets: ["latin"],
+  weight: ["400", "500", "600"],
 });
 
 export const metadata: Metadata = {
@@ -27,7 +28,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50 dark:bg-gray-950`}
+        className={`${inter.variable} ${ibmPlexMono.variable} antialiased bg-gray-50 dark:bg-gray-950`}
       >
         <QueryProvider>
           <Header />


### PR DESCRIPTION
# Update Typography: Replace Geist fonts with Inter and IBM Plex Mono

## Summary
- Replace Geist Sans with **Inter** as the primary font for improved readability and modern aesthetic
- Replace Geist Mono with **IBM Plex Mono** for enhanced code block and monospace typography  
- Update CSS variables and Tailwind font configuration to support the new fonts
- Add multiple font weights (400, 500, 600) for IBM Plex Mono to provide better typographical flexibility

## Changes Made
- **`app/layout.tsx`**: Updated font imports from `next/font/google` and font variable configurations
- **`app/globals.css`**: Updated CSS custom properties and font fallback declarations

## Impact
This typography update enhances the overall user experience by providing:
- Better readability with Inter's optimized letter spacing and modern character design
- Improved code readability with IBM Plex Mono's clear character differentiation
- Consistent brand identity with contemporary font choices
- Enhanced accessibility through Inter's excellent legibility at various sizes

## Testing
- ✅ Build passes successfully with new font configuration
- ✅ Font variables properly configured in Tailwind CSS
- ✅ No breaking changes to existing components

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/f3ef5af1-b903-4b2b-b9c5-227415c95a73/task/96f9c676-a7c6-4ba6-9003-da6a02e12224))